### PR TITLE
Rename routes to translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Alternatively, you can compile the translations to resources/js in your dev and 
 ```js
 // zora.js
 
-const Ziggy = {
+const Zora = {
     translations: {"en": {"php": {}, "json": {}}};
 };
 if (typeof window !== 'undefined' && typeof window.Zora !== 'undefined') {
-  Object.assign(Zora.routes, window.Zora.routes);
+  Object.assign(Zora.translations, window.Zora.translations);
 }
 
 export { Zora }

--- a/src/CommandTranslationGenerator.php
+++ b/src/CommandTranslationGenerator.php
@@ -83,7 +83,7 @@ class CommandTranslationGenerator extends Command
 const Zora = { translations: $json }
 
 if (typeof window !== 'undefined' && typeof window.Zora !== 'undefined') {
-  Object.assign(Zora.routes, window.Zora.routes);
+  Object.assign(Zora.translations, window.Zora.translations);
 }
 
 export { Zora }


### PR DESCRIPTION
this should throw an error but never used because the client.js by pass this code. windwo.Zora is never used.